### PR TITLE
Implement basic CRUD for main page to-do list

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,132 @@
-import Image from "next/image";
+import { revalidatePath } from "next/cache";
+import prisma from "./lib/prisma";
 
-export default function Home() {
+// Server actions
+async function createTodo(formData: FormData) {
+  "use server";
+  const title = String(formData.get("title") || "").trim();
+  const description = String(formData.get("description") || "").trim() || undefined;
+  if (!title) return;
+  await prisma.todo.create({ data: { title, description } });
+  revalidatePath("/");
+}
+
+async function updateTodoTitle(id: number, formData: FormData) {
+  "use server";
+  const title = String(formData.get("title") || "").trim();
+  const descriptionRaw = formData.get("description");
+  const description = descriptionRaw !== null ? String(descriptionRaw).trim() : undefined;
+  if (!title) return;
+  await prisma.todo.update({ where: { id }, data: { title, description } });
+  revalidatePath("/");
+}
+
+async function toggleTodo(id: number) {
+  "use server";
+  const todo = await prisma.todo.findUnique({ where: { id } });
+  if (!todo) return;
+  await prisma.todo.update({ where: { id }, data: { completed: !todo.completed } });
+  revalidatePath("/");
+}
+
+async function deleteTodo(id: number) {
+  "use server";
+  await prisma.todo.delete({ where: { id } });
+  revalidatePath("/");
+}
+
+export default async function Home() {
+  const todos = await prisma.todo.findMany({ orderBy: { createdAt: "desc" } });
+
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+    <div className="font-sans min-h-screen p-8 sm:p-12">
+      <main className="mx-auto max-w-2xl flex flex-col gap-8">
+        <h1 className="text-2xl font-semibold">To-do List</h1>
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
+        {/* Create */}
+        <form action={createTodo} className="flex flex-col gap-2 rounded-lg border border-black/10 dark:border-white/15 p-4">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              name="title"
+              placeholder="What do you need to do?"
+              className="flex-1 rounded-md border border-black/10 dark:border-white/15 bg-transparent px-3 py-2 outline-none"
+              required
             />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
+            <button type="submit" className="rounded-md bg-foreground text-background px-4 py-2 text-sm font-medium hover:opacity-90">
+              Add
+            </button>
+          </div>
+          <textarea
+            name="description"
+            placeholder="Optional description"
+            className="rounded-md border border-black/10 dark:border-white/15 bg-transparent px-3 py-2 outline-none resize-y min-h-10"
+          />
+        </form>
+
+        {/* List */}
+        <ul className="flex flex-col gap-4">
+          {todos.length === 0 && (
+            <li className="text-sm text-black/60 dark:text-white/60">No todos yet. Add one above.</li>
+          )}
+          {todos.map((t) => (
+            <li key={t.id} className="rounded-lg border border-black/10 dark:border-white/15 p-4">
+              <div className="flex items-start gap-3">
+                {/* Toggle */}
+                <form action={toggleTodo.bind(null, t.id)}>
+                  <button
+                    type="submit"
+                    title={t.completed ? "Mark as incomplete" : "Mark as complete"}
+                    className={`size-5 rounded border border-black/15 dark:border-white/20 inline-flex items-center justify-center ${
+                      t.completed ? "bg-green-600" : "bg-transparent"
+                    }`}
+                    aria-pressed={t.completed}
+                  >
+                    {t.completed ? "✓" : ""}
+                  </button>
+                </form>
+
+                {/* Edit */}
+                <div className="flex-1">
+                  <form action={updateTodoTitle.bind(null, t.id)} className="flex flex-col gap-2">
+                    <input
+                      type="text"
+                      name="title"
+                      defaultValue={t.title}
+                      className="w-full rounded-md border border-black/10 dark:border-white/15 bg-transparent px-3 py-2 outline-none line-through:data-[completed=true]"
+                      data-completed={t.completed}
+                      required
+                    />
+                    <textarea
+                      name="description"
+                      defaultValue={t.description ?? ""}
+                      placeholder="Add a description (optional)"
+                      className="rounded-md border border-black/10 dark:border-white/15 bg-transparent px-3 py-2 outline-none resize-y min-h-10"
+                    />
+                    <div className="flex gap-2 justify-end">
+                      <button type="submit" className="rounded-md border border-black/10 dark:border-white/20 px-3 py-1 text-sm hover:bg-black/5 dark:hover:bg-white/10">
+                        Save
+                      </button>
+                    </div>
+                  </form>
+                </div>
+
+                {/* Delete */}
+                <form action={deleteTodo.bind(null, t.id)} className="self-start">
+                  <button
+                    type="submit"
+                    className="rounded-md border border-red-500/40 text-red-600 dark:text-red-400 px-3 py-1 text-sm hover:bg-red-500/10"
+                    title="Delete"
+                  >
+                    Delete
+                  </button>
+                </form>
+              </div>
+            </li>
+          ))}
+        </ul>
       </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
     </div>
   );
 }
+


### PR DESCRIPTION
This PR implements a simple to-do list app on the main page using Prisma and Next.js server actions.

What’s included
- Read: Fetch and display todos ordered by newest first
- Create: Form to add a new todo with optional description
- Update: Inline edit form for title and description
- Toggle: Mark as complete/incomplete
- Delete: Remove a todo
- Revalidation: Uses `revalidatePath('/')` after mutations for instant UI refresh

Technical details
- Uses the existing Prisma client from `app/lib/prisma.ts`
- Server Actions defined in `app/page.tsx` to keep scope small and focused
- Minimal Tailwind styling for clarity

How to use
1. Start the dev server: `npm run dev`
2. Ensure your database has been migrated and `DATABASE_URL` is set
3. Open `http://localhost:3000` and add/manage todos

Notes
- Relies on the existing `Todo` model in Prisma schema
- No additional routes or API handlers are required; all mutations are performed via server actions

Let me know if you want this broken out into separate components or API routes.

Closes #1