### PR TITLE
Add gradient colors for a modern, casual look

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,10 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  /* Soft, friendly gradient background (light) */
+  --bg-gradient: radial-gradient(1200px circle at 0% -20%, rgba(56, 189, 248, 0.28), transparent 35%),
+    radial-gradient(900px circle at 100% 0%, rgba(192, 132, 252, 0.22), transparent 30%),
+    linear-gradient(180deg, #ffffff 0%, #fff8f5 100%);
 }
 
 @theme inline {
@@ -16,11 +20,17 @@
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    /* Subtle, moody gradient background (dark) */
+    --bg-gradient: radial-gradient(1200px circle at 0% -20%, rgba(56, 189, 248, 0.15), transparent 35%),
+      radial-gradient(900px circle at 100% 0%, rgba(192, 132, 252, 0.12), transparent 30%),
+      linear-gradient(180deg, #0a0a0a 0%, #0f0f12 100%);
   }
 }
 
 body {
-  background: var(--background);
+  background: var(--bg-gradient);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  background-attachment: fixed;
 }
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,10 +42,15 @@ export default async function Home() {
   return (
     <div className="font-sans min-h-screen p-8 sm:p-12">
       <main className="mx-auto max-w-2xl flex flex-col gap-8">
-        <h1 className="text-2xl font-semibold">To-do List</h1>
+        <h1 className="text-3xl sm:text-4xl font-semibold bg-gradient-to-r from-indigo-500 via-sky-500 to-emerald-500 bg-clip-text text-transparent">
+          To-do List
+        </h1>
 
         {/* Create */}
-        <form action={createTodo} className="flex flex-col gap-2 rounded-lg border border-black/10 dark:border-white/15 p-4">
+        <form
+          action={createTodo}
+          className="flex flex-col gap-2 rounded-xl border border-black/10 dark:border-white/15 p-4 bg-white/60 dark:bg-white/5 backdrop-blur-md shadow-sm"
+        >
           <div className="flex gap-2">
             <input
               type="text"
@@ -55,7 +60,7 @@ export default async function Home() {
               required
             />
             <SubmitButton
-              className="rounded-md bg-foreground text-background px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed"
+              className="rounded-md bg-gradient-to-r from-indigo-500 via-sky-500 to-emerald-500 text-white px-4 py-2 text-sm font-medium shadow hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/50 disabled:opacity-60 disabled:cursor-not-allowed"
               pendingChildren="Adding..."
             >
               Add
@@ -74,7 +79,10 @@ export default async function Home() {
             <li className="text-sm text-black/60 dark:text-white/60">No todos yet. Add one above.</li>
           )}
           {todos.map((t) => (
-            <li key={t.id} className="rounded-lg border border-black/10 dark:border-white/15 p-4">
+            <li
+              key={t.id}
+              className="rounded-xl border border-black/10 dark:border-white/15 p-4 bg-white/60 dark:bg-white/5 backdrop-blur-md shadow-sm"
+            >
               <div className="flex items-start gap-3">
                 {/* Toggle */}
                 <form action={toggleTodo.bind(null, t.id)}>


### PR DESCRIPTION
This PR refreshes the UI with tasteful gradients to make it feel more professional yet fun and casual, as requested.

What’s included
- Global background: Introduces soft radial + linear gradient backgrounds for both light and dark modes for a fresh, modern vibe.
- Heading accent: The main title now has a subtle multi-color gradient text treatment.
- Primary action button: The Add button uses a friendly indigo → sky → emerald gradient and retains pending/disabled states via the existing SubmitButton component.
- Card styling: Forms and list items use translucent surfaces with a slight backdrop blur for a light “glass” feel, preserving readability over the gradient background.

Implementation notes
- CSS variables: Added --bg-gradient in app/globals.css with light/dark variants and applied it to the body background. Kept existing foreground/background variables intact.
- Tailwind utilities: Leveraged Tailwind v4 gradient utilities and backdrop blur classes; no new dependencies or config changes.
- Preserved behavior: All server actions and the SubmitButton loading states remain intact.

Why this approach
- Minimal, focused change set that updates the visual style without altering app logic.
- Works with system dark mode preferences and keeps accessibility/contrast in mind.

Screens and components touched
- app/globals.css
- app/page.tsx

I ran eslint locally and it passes. Let me know if you want the Save button or other elements to adopt gradient accents as well, or if you prefer a different color palette.

Closes #4